### PR TITLE
Changed import scheme for compliance with pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Its main features are:
 
 - Generate a new python environment using [anaconda](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
 or [pip](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
-  - Install required Python packages (see [pyproject.toml](pyproject.toml)) in the environment
 - Download or clone autoprot
   - If you clone the repository, make sure to include the dependencies as submodules (example below)
 
@@ -40,7 +39,23 @@ git clone --recurse-submodules https://github.com/ag-warscheid/autoprot.git
 git submodule update --init --recursive
 ```
 
-- Next you need to install R. Please follow the instructions at the [R manual](https://cran.r-project.org/index.html) and install R to a custom location
+- Install autoprot to your Python env using
+
+```
+cd autoprot
+pip install .
+```
+- Next you need to install R. Please follow the instructions from the [R manual](https://cran.r-project.org/index.html) and install R to a custom location
+  - On Linux you could typically do
+
+```bash
+wget https://cran.r-project.org/src/base/R-4/R-4.5.3.tar.gz
+tar -xzf R-4.5.3.tar.gz
+cd R-4.5.3
+./configure
+make
+```
+
 - Start autoprot by importing it from any Python console you like. It will generate an autoprot.conf file in the autoprot package directory that you need to edit.
   - Insert the path to your Rscript executable that you just installed as value for the R variable
   - The RFunctions variable should point the RFunctions.R file from autoprot.

--- a/autoprot/__init__.py
+++ b/autoprot/__init__.py
@@ -1,5 +1,7 @@
 import sys
 from . import common
+from . import r_helper
+from . import decorators
 
 __version__ = "dev"
 __author__ = "The autoprot contributors"
@@ -9,6 +11,7 @@ __license__ = "BSD-3-Clause"
 module_pointer = sys.modules[__name__]
 # we can explicitly make assignments on it
 module_pointer.check_r_install = False
-
 # write the environment.txt file
 common.generate_environment_txt()
+
+from . import preprocessing

--- a/autoprot/__init__.py
+++ b/autoprot/__init__.py
@@ -1,7 +1,8 @@
 import sys
+
 from . import common
-from . import r_helper
 from . import decorators
+from . import r_helper
 
 __version__ = "dev"
 __author__ = "The autoprot contributors"

--- a/autoprot/analysis/PCA.py
+++ b/autoprot/analysis/PCA.py
@@ -9,15 +9,14 @@ Autoprot Analysis Functions.
 
 from typing import Union, Literal
 
-import pandas as pd
-import numpy as np
 import matplotlib.pylab as plt
+import numpy as np
+import pandas as pd
 import seaborn as sns
-
-from sklearn.decomposition import PCA
-from autoprot import r_helper
-
 from gprofiler import GProfiler
+from sklearn.decomposition import PCA
+
+from autoprot import r_helper
 
 gp = GProfiler(user_agent="autoprot", return_dataframe=True)
 RFUNCTIONS, R = r_helper.return_r_path()

--- a/autoprot/analysis/PCA.py
+++ b/autoprot/analysis/PCA.py
@@ -15,7 +15,7 @@ import matplotlib.pylab as plt
 import seaborn as sns
 
 from sklearn.decomposition import PCA
-from .. import r_helper
+from autoprot import r_helper
 
 from gprofiler import GProfiler
 
@@ -24,6 +24,8 @@ RFUNCTIONS, R = r_helper.return_r_path()
 
 # check where this is actually used and make it local
 cmap = sns.diverging_palette(150, 275, s=80, l=55, n=9)
+
+__all__ = ["AutoPCA"]
 
 
 class AutoPCA:

--- a/autoprot/analysis/__init__.py
+++ b/autoprot/analysis/__init__.py
@@ -1,16 +1,16 @@
+from .PCA import *
 from .clustering import *
 from .functional import *
-from .PCA import *
 from .qc import *
 from .stat_test import *
 from .stats import *
 
 # Optional: define what's exported when someone does `from analysis import *`
 __all__ = [
-    'clustering',
-    'functional',
-    'PCA',
-    'qc',
-    'stat_test',
-    'stats',
+    "clustering",
+    "functional",
+    "PCA",
+    "qc",
+    "stat_test",
+    "stats",
 ]

--- a/autoprot/analysis/__init__.py
+++ b/autoprot/analysis/__init__.py
@@ -4,3 +4,13 @@ from .PCA import *
 from .qc import *
 from .stat_test import *
 from .stats import *
+
+# Optional: define what's exported when someone does `from analysis import *`
+__all__ = [
+    'clustering',
+    'functional',
+    'PCA',
+    'qc',
+    'stat_test',
+    'stats',
+]

--- a/autoprot/analysis/clustering.py
+++ b/autoprot/analysis/clustering.py
@@ -30,13 +30,15 @@ from sklearn.metrics import (
     davies_bouldin_score,
 )
 
-from .. import r_helper
+from autoprot import r_helper
 
 gp = GProfiler(user_agent="autoprot", return_dataframe=True)
 RFUNCTIONS, R = r_helper.return_r_path()
 
 # check where this is actually used and make it local
 cmap = sns.diverging_palette(150, 275, s=80, l=55, n=9)
+
+__all__ = ["HCA", "KMeans"]
 
 
 class _Cluster:

--- a/autoprot/analysis/clustering.py
+++ b/autoprot/analysis/clustering.py
@@ -16,10 +16,10 @@ import matplotlib.colors as clrs
 import matplotlib.pylab as plt
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_numeric_dtype
 import seaborn as sns
 from gprofiler import GProfiler
 from numpy.typing import ArrayLike
+from pandas.api.types import is_numeric_dtype
 from scipy import cluster as clst
 from scipy.spatial import distance
 from scipy.stats import zscore

--- a/autoprot/analysis/functional.py
+++ b/autoprot/analysis/functional.py
@@ -11,15 +11,14 @@ from functools import reduce
 from importlib import resources
 from typing import Union, Literal, List, Dict, Any, Tuple
 
-import pandas as pd
-import numpy as np
 import matplotlib.pylab as plt
+import numpy as np
+import pandas as pd
 import seaborn as sns
-
-from autoprot import visualization as vis
-from autoprot import r_helper
-
 from gprofiler import GProfiler
+
+from autoprot import r_helper
+from autoprot import visualization as vis
 
 gp = GProfiler(user_agent="autoprot", return_dataframe=True)
 RFUNCTIONS, R = r_helper.return_r_path()

--- a/autoprot/analysis/functional.py
+++ b/autoprot/analysis/functional.py
@@ -16,8 +16,8 @@ import numpy as np
 import matplotlib.pylab as plt
 import seaborn as sns
 
-from .. import visualization as vis
-from .. import r_helper
+from autoprot import visualization as vis
+from autoprot import r_helper
 
 from gprofiler import GProfiler
 
@@ -26,6 +26,8 @@ RFUNCTIONS, R = r_helper.return_r_path()
 
 # check where this is actually used and make it local
 cmap = sns.diverging_palette(150, 275, s=80, l=55, n=9)
+
+__all__ = ["go_analysis", "KSEA"]
 
 
 def go_analysis(

--- a/autoprot/analysis/qc.py
+++ b/autoprot/analysis/qc.py
@@ -242,10 +242,8 @@ def missed_cleavages(df_evidence, enzyme="Trypsin/P", save=True, ax=None, title=
     today = date.today().isoformat()
 
     if "Experiment" not in df_evidence.columns.tolist():
-        print(
-            "Warning: Column [Experiment] either not unique or missing,\n\
-              column [Raw file] used"
-        )
+        print("Warning: Column [Experiment] either not unique or missing,\n\
+              column [Raw file] used")
         experiments = list(set((df_evidence["Raw file"])))
     else:
         experiments = list(set((df_evidence["Experiment"])))
@@ -253,10 +251,8 @@ def missed_cleavages(df_evidence, enzyme="Trypsin/P", save=True, ax=None, title=
     rawfiles = list(set((df_evidence["Raw file"])))
     if len(experiments) != len(rawfiles):
         experiments = rawfiles
-        print(
-            "Warning: Column [Experiment] either not unique or missing,\n\
-              column [Raw file] used"
-        )
+        print("Warning: Column [Experiment] either not unique or missing,\n\
+              column [Raw file] used")
 
     # calculate miss cleavage for each raw file in df_evidence
     df_missed_cleavage_summary = pd.DataFrame()
@@ -613,10 +609,8 @@ def dimethyl_labeling_efficieny(df_evidence, label, save=True) -> pd.DataFrame:
         experiments = list((df_evidence["Experiment"].unique()))
     else:
         experiments = list((df_evidence["Raw file"].unique()))
-        print(
-            "Warning: Column [Experiment] either not unique or missing,\n\
-              column [Raw file] used"
-        )
+        print("Warning: Column [Experiment] either not unique or missing,\n\
+              column [Raw file] used")
 
     df_labeling_eff = pd.DataFrame()
 

--- a/autoprot/analysis/qc.py
+++ b/autoprot/analysis/qc.py
@@ -17,7 +17,7 @@ import seaborn as sns
 from operator import itemgetter
 import missingno as msn
 
-from .. import r_helper
+from autoprot import r_helper
 
 from gprofiler import GProfiler
 
@@ -26,6 +26,15 @@ RFUNCTIONS, R = r_helper.return_r_path()
 
 # check where this is actually used and make it local
 cmap = sns.diverging_palette(150, 275, s=80, l=55, n=9)
+
+__all__ = [
+    "miss_analysis",
+    "missed_cleavages",
+    "enrichment_specificity",
+    "SILAC_labeling_efficiency",
+    "dimethyl_labeling_efficieny",
+    "tmt6plex_labeling_efficiency",
+]
 
 
 def miss_analysis(
@@ -234,8 +243,10 @@ def missed_cleavages(df_evidence, enzyme="Trypsin/P", save=True, ax=None, title=
     today = date.today().isoformat()
 
     if "Experiment" not in df_evidence.columns.tolist():
-        print("Warning: Column [Experiment] either not unique or missing,\n\
-              column [Raw file] used")
+        print(
+            "Warning: Column [Experiment] either not unique or missing,\n\
+              column [Raw file] used"
+        )
         experiments = list(set((df_evidence["Raw file"])))
     else:
         experiments = list(set((df_evidence["Experiment"])))
@@ -243,8 +254,10 @@ def missed_cleavages(df_evidence, enzyme="Trypsin/P", save=True, ax=None, title=
     rawfiles = list(set((df_evidence["Raw file"])))
     if len(experiments) != len(rawfiles):
         experiments = rawfiles
-        print("Warning: Column [Experiment] either not unique or missing,\n\
-              column [Raw file] used")
+        print(
+            "Warning: Column [Experiment] either not unique or missing,\n\
+              column [Raw file] used"
+        )
 
     # calculate miss cleavage for each raw file in df_evidence
     df_missed_cleavage_summary = pd.DataFrame()
@@ -601,8 +614,10 @@ def dimethyl_labeling_efficieny(df_evidence, label, save=True) -> pd.DataFrame:
         experiments = list((df_evidence["Experiment"].unique()))
     else:
         experiments = list((df_evidence["Raw file"].unique()))
-        print("Warning: Column [Experiment] either not unique or missing,\n\
-              column [Raw file] used")
+        print(
+            "Warning: Column [Experiment] either not unique or missing,\n\
+              column [Raw file] used"
+        )
 
     df_labeling_eff = pd.DataFrame()
 

--- a/autoprot/analysis/qc.py
+++ b/autoprot/analysis/qc.py
@@ -7,19 +7,18 @@ Autoprot Analysis Functions.
 @documentation: Julian
 """
 
-from typing import Literal
 from datetime import date
-
-import pandas as pd
-import numpy as np
-import matplotlib.pylab as plt
-import seaborn as sns
 from operator import itemgetter
+from typing import Literal
+
+import matplotlib.pylab as plt
 import missingno as msn
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from gprofiler import GProfiler
 
 from autoprot import r_helper
-
-from gprofiler import GProfiler
 
 gp = GProfiler(user_agent="autoprot", return_dataframe=True)
 RFUNCTIONS, R = r_helper.return_r_path()

--- a/autoprot/analysis/stat_test.py
+++ b/autoprot/analysis/stat_test.py
@@ -17,14 +17,16 @@ from matplotlib import pylab as pl
 from scipy.stats import ttest_1samp, ttest_ind
 from statsmodels.stats import multitest as mt
 
-from .. import preprocessing as pp
-from .. import r_helper
+from autoprot import preprocessing as pp
+from autoprot import r_helper
 
 gp = GProfiler(user_agent="autoprot", return_dataframe=True)
 RFUNCTIONS, R = r_helper.return_r_path()
 
 # check where this is actually used and make it local
 cmap = sns.diverging_palette(150, 275, s=80, l=55, n=9)
+
+__all__ = ["ttest", "adjust_p", "cohen_d", "limma", "rank_prod"]
 
 
 def ttest(

--- a/autoprot/analysis/stats.py
+++ b/autoprot/analysis/stats.py
@@ -12,7 +12,7 @@ import numpy as np
 import matplotlib.pylab as plt
 import seaborn as sns
 
-from .. import r_helper
+from autoprot import r_helper
 
 from gprofiler import GProfiler
 
@@ -21,6 +21,8 @@ RFUNCTIONS, R = r_helper.return_r_path()
 
 # check where this is actually used and make it local
 cmap = sns.diverging_palette(150, 275, s=80, l=55, n=9)
+
+__all__ = ["edm", "loess", "make_psm"]
 
 
 def edm(matrix_a, matrix_b):

--- a/autoprot/analysis/stats.py
+++ b/autoprot/analysis/stats.py
@@ -7,14 +7,13 @@ Autoprot Analysis Functions.
 @documentation: Julian
 """
 
-import pandas as pd
-import numpy as np
 import matplotlib.pylab as plt
+import numpy as np
+import pandas as pd
 import seaborn as sns
+from gprofiler import GProfiler
 
 from autoprot import r_helper
-
-from gprofiler import GProfiler
 
 gp = GProfiler(user_agent="autoprot", return_dataframe=True)
 RFUNCTIONS, R = r_helper.return_r_path()

--- a/autoprot/preprocessing/__init__.py
+++ b/autoprot/preprocessing/__init__.py
@@ -5,3 +5,14 @@ from .imputation import *
 from .normalization import *
 from .transformation import *
 from .diann import *
+
+# Optional: define what's exported when someone does `from preprocessing import *`
+__all__ = [
+    'annotation',
+    'data_handling',
+    'filtering',
+    'imputation',
+    'normalization',
+    'transformation',
+    'diann'
+]

--- a/autoprot/preprocessing/__init__.py
+++ b/autoprot/preprocessing/__init__.py
@@ -1,18 +1,18 @@
 from .annotation import *
 from .data_handling import *
+from .diann import *
 from .filtering import *
 from .imputation import *
 from .normalization import *
 from .transformation import *
-from .diann import *
 
 # Optional: define what's exported when someone does `from preprocessing import *`
 __all__ = [
-    'annotation',
-    'data_handling',
-    'filtering',
-    'imputation',
-    'normalization',
-    'transformation',
-    'diann'
+    "annotation",
+    "data_handling",
+    "filtering",
+    "imputation",
+    "normalization",
+    "transformation",
+    "diann",
 ]

--- a/autoprot/preprocessing/annotation.py
+++ b/autoprot/preprocessing/annotation.py
@@ -16,13 +16,14 @@ import numpy as np
 import pandas as pd
 import requests
 
-# noinspection PyPackageRequirements
 from Bio import Align
-from .. import r_helper, common
+from autoprot import r_helper, common
 from autoprot.decorators import report
 
 RFUNCTIONS, R = r_helper.return_r_path()
 
+# defines which functions are exposed at the module level
+__all__ = ['go_annot', 'motif_annot', 'annotate_phosphosite', 'to_canonical_ps', 'get_subcellular_loc']
 
 # =============================================================================
 # Note: When using R functions provided column names might get changed

--- a/autoprot/preprocessing/annotation.py
+++ b/autoprot/preprocessing/annotation.py
@@ -15,15 +15,21 @@ from typing import Union, Tuple
 import numpy as np
 import pandas as pd
 import requests
-
 from Bio import Align
+
 from autoprot import r_helper, common
 from autoprot.decorators import report
 
 RFUNCTIONS, R = r_helper.return_r_path()
 
 # defines which functions are exposed at the module level
-__all__ = ['go_annot', 'motif_annot', 'annotate_phosphosite', 'to_canonical_ps', 'get_subcellular_loc']
+__all__ = [
+    "go_annot",
+    "motif_annot",
+    "annotate_phosphosite",
+    "to_canonical_ps",
+    "get_subcellular_loc",
+]
 
 # =============================================================================
 # Note: When using R functions provided column names might get changed

--- a/autoprot/preprocessing/data_handling.py
+++ b/autoprot/preprocessing/data_handling.py
@@ -13,6 +13,8 @@ import requests
 from urllib import parse
 from ftplib import FTP
 
+# defines which functions are exposed at the module level
+__all__ = ['read_csv', 'to_csv', 'download_from_ftp', 'fetch_from_pride',]
 
 def read_csv(file, sep="\t", low_memory=False, **kwargs):
     r"""

--- a/autoprot/preprocessing/data_handling.py
+++ b/autoprot/preprocessing/data_handling.py
@@ -7,14 +7,21 @@ Autoprot Preprocessing Functions.
 @documentation: Julian
 """
 
-import pandas as pd
 import os
-import requests
-from urllib import parse
 from ftplib import FTP
+from urllib import parse
+
+import pandas as pd
+import requests
 
 # defines which functions are exposed at the module level
-__all__ = ['read_csv', 'to_csv', 'download_from_ftp', 'fetch_from_pride',]
+__all__ = [
+    "read_csv",
+    "to_csv",
+    "download_from_ftp",
+    "fetch_from_pride",
+]
+
 
 def read_csv(file, sep="\t", low_memory=False, **kwargs):
     r"""

--- a/autoprot/preprocessing/diann.py
+++ b/autoprot/preprocessing/diann.py
@@ -91,16 +91,16 @@ def parquet_to_pg(
     reset_index: bool = True,
 ) -> pd.DataFrame:
     """
-    Load DIANN SILAC precursor data from a Parquet file and convert to protein group-level intensities.
+    Load DIANN precursor data from a Parquet file and convert to protein group-level intensities.
     """
     rp = load_parquet(path, filters=filters, mbr=mbr, crap_str=crap_str)
 
-    # Select relevant columns and drop duplicates
-    pg = rp[["Run", "Protein.Group", "Genes", "PG.MaxLFQ"]].drop_duplicates().copy()
-    pg["PG.MaxLFQ"] = pg["PG.MaxLFQ"].replace(0, pd.NA)
-
     if index_cols is None:
         index_cols = ["Protein.Group", "Genes"]
+
+    # Select relevant columns and drop duplicates
+    pg = rp[["Run", "PG.MaxLFQ"] + index_cols].drop_duplicates().copy()
+    pg["PG.MaxLFQ"] = pg["PG.MaxLFQ"].replace(0, pd.NA)
 
     pg = pg.pivot_table(
         index=index_cols,
@@ -112,7 +112,7 @@ def parquet_to_pg(
     # convert numerical columns to float
     pg = pg.astype(float)
 
-    print(f"Aggretation to protein group level done. Final shape: {pg.shape}")
+    print(f"Aggregation to protein group level done. Final shape: {pg.shape}")
 
     if reset_index:
         pg = pg.reset_index()

--- a/autoprot/preprocessing/diann.py
+++ b/autoprot/preprocessing/diann.py
@@ -5,6 +5,8 @@ from itertools import combinations
 import numpy as np
 import pandas as pd
 
+# defines which functions are exposed at the module level
+__all__ = ['load_parquet', 'parquet_to_pg', 'silac_protein_group_from_diann']
 
 def load_parquet(
     path, filters: dict = None, mbr: bool = True, crap_str: str | list[str] = "cRAP"

--- a/autoprot/preprocessing/diann.py
+++ b/autoprot/preprocessing/diann.py
@@ -1,12 +1,14 @@
+import multiprocessing
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-import multiprocessing
 from itertools import combinations
+
 import numpy as np
 import pandas as pd
 
 # defines which functions are exposed at the module level
-__all__ = ['load_parquet', 'parquet_to_pg', 'silac_protein_group_from_diann']
+__all__ = ["load_parquet", "parquet_to_pg", "silac_protein_group_from_diann"]
+
 
 def load_parquet(
     path, filters: dict = None, mbr: bool = True, crap_str: str | list[str] = "cRAP"

--- a/autoprot/preprocessing/filtering.py
+++ b/autoprot/preprocessing/filtering.py
@@ -8,18 +8,24 @@ Autoprot Preprocessing Functions.
 """
 
 import functools
+from typing import Literal
 
 import numpy as np
 import pandas as pd
-from typing import Literal
 
-from autoprot.decorators import report
 from autoprot import r_helper
+from autoprot.decorators import report
 
 RFUNCTIONS, R = r_helper.return_r_path()
 
 # defines which functions are exposed at the module level
-__all__ = ['cleaning', 'filter_loc_prob', 'filter_seq_cov', 'filter_vv', 'remove_non_quant']
+__all__ = [
+    "cleaning",
+    "filter_loc_prob",
+    "filter_seq_cov",
+    "filter_vv",
+    "remove_non_quant",
+]
 
 # =============================================================================
 # Note: When using R functions provided column names might get changed

--- a/autoprot/preprocessing/filtering.py
+++ b/autoprot/preprocessing/filtering.py
@@ -14,10 +14,12 @@ import pandas as pd
 from typing import Literal
 
 from autoprot.decorators import report
-from .. import r_helper
+from autoprot import r_helper
 
 RFUNCTIONS, R = r_helper.return_r_path()
 
+# defines which functions are exposed at the module level
+__all__ = ['cleaning', 'filter_loc_prob', 'filter_seq_cov', 'filter_vv', 'remove_non_quant']
 
 # =============================================================================
 # Note: When using R functions provided column names might get changed

--- a/autoprot/preprocessing/imputation.py
+++ b/autoprot/preprocessing/imputation.py
@@ -11,12 +11,13 @@ import numpy as np
 import pandas as pd
 from subprocess import run, PIPE, STDOUT
 from typing import Union
-from .. import r_helper
-from .. import preprocessing as pp
+from autoprot import r_helper
+from autoprot import preprocessing as pp
 
 RFUNCTIONS, R = r_helper.return_r_path()
 
-
+# defines which functions are exposed at the module level
+__all__ = ['imp_min_prob', 'imp_median', 'imp_seq', 'dima']
 # =============================================================================
 # Note: When using R functions provided column names might get changed
 # Especially, do not use +,- or spaces in your column names. Maybe write decorator to

--- a/autoprot/preprocessing/imputation.py
+++ b/autoprot/preprocessing/imputation.py
@@ -7,17 +7,19 @@ Autoprot Preprocessing Functions.
 @documentation: Julian
 """
 
-import numpy as np
-import pandas as pd
 from subprocess import run, PIPE, STDOUT
 from typing import Union
-from autoprot import r_helper
+
+import numpy as np
+import pandas as pd
+
 from autoprot import preprocessing as pp
+from autoprot import r_helper
 
 RFUNCTIONS, R = r_helper.return_r_path()
 
 # defines which functions are exposed at the module level
-__all__ = ['imp_min_prob', 'imp_median', 'imp_seq', 'dima']
+__all__ = ["imp_min_prob", "imp_median", "imp_seq", "dima"]
 # =============================================================================
 # Note: When using R functions provided column names might get changed
 # Especially, do not use +,- or spaces in your column names. Maybe write decorator to

--- a/autoprot/preprocessing/normalization.py
+++ b/autoprot/preprocessing/normalization.py
@@ -7,17 +7,19 @@ Autoprot Preprocessing Functions.
 @documentation: Julian
 """
 
-import numpy as np
-import pandas as pd
 import os
 from typing import Union, Literal, Tuple, List
-from autoprot import r_helper
+
+import numpy as np
+import pandas as pd
+
 from autoprot import preprocessing as pp
+from autoprot import r_helper
 
 RFUNCTIONS, R = r_helper.return_r_path()
 
 # defines which functions are exposed at the module level
-__all__ = ['loading_norm', 'quantile_norm', 'vsn', 'cyclic_loess', 'norm_to_prot']
+__all__ = ["loading_norm", "quantile_norm", "vsn", "cyclic_loess", "norm_to_prot"]
 
 # =============================================================================
 # Note: When using R functions provided column names might get changed

--- a/autoprot/preprocessing/normalization.py
+++ b/autoprot/preprocessing/normalization.py
@@ -11,11 +11,13 @@ import numpy as np
 import pandas as pd
 import os
 from typing import Union, Literal, Tuple, List
-from .. import r_helper
-from .. import preprocessing as pp
+from autoprot import r_helper
+from autoprot import preprocessing as pp
 
 RFUNCTIONS, R = r_helper.return_r_path()
 
+# defines which functions are exposed at the module level
+__all__ = ['loading_norm', 'quantile_norm', 'vsn', 'cyclic_loess', 'norm_to_prot']
 
 # =============================================================================
 # Note: When using R functions provided column names might get changed

--- a/autoprot/preprocessing/transformation.py
+++ b/autoprot/preprocessing/transformation.py
@@ -20,21 +20,25 @@ from typing import Union, Literal, Sequence
 
 import numpy as np
 import pandas as pd
-from pandas.core.groupby.generic import DataFrameGroupBy
 import requests
-from pandas.core.groupby import DataFrameGroupBy
+from pandera.typing import DataFrame as PandasDataFrame
 from scipy import stats
 from scipy.stats import pearsonr, spearmanr
 from sklearn.metrics import auc
-
-from pandera.typing import Series as PandasSeries
-from pandera.typing import DataFrame as PandasDataFrame
 
 from autoprot import r_helper, common
 
 RFUNCTIONS, R = r_helper.return_r_path()
 # defines which functions are exposed at the module level
-__all__ = ['log', 'expand_site_table', 'collapse_rows', 'exp_semi_col', 'merge_semi_cols', 'calculate_iBAQ', 'merge_semi_cols']
+__all__ = [
+    "log",
+    "expand_site_table",
+    "collapse_rows",
+    "exp_semi_col",
+    "merge_semi_cols",
+    "calculate_iBAQ",
+    "merge_semi_cols",
+]
 
 # =============================================================================
 # Note: When using R functions provided column names might get changed
@@ -128,8 +132,10 @@ def log(
     try:
         keep = df[cols] > 0
     except TypeError:
-        raise TypeError(f"[log] Could not mask negative an NaN values in columns {', '.join(cols)}."
-                        f" Please check if they are all numerical.")
+        raise TypeError(
+            f"[log] Could not mask negative an NaN values in columns {', '.join(cols)}."
+            f" Please check if they are all numerical."
+        )
 
     # Apply log transformation to all columns at once
     log_values = np.log(df[cols].where(keep)) / np.log(base)

--- a/autoprot/preprocessing/transformation.py
+++ b/autoprot/preprocessing/transformation.py
@@ -30,10 +30,11 @@ from sklearn.metrics import auc
 from pandera.typing import Series as PandasSeries
 from pandera.typing import DataFrame as PandasDataFrame
 
-from .. import r_helper, common
+from autoprot import r_helper, common
 
 RFUNCTIONS, R = r_helper.return_r_path()
-
+# defines which functions are exposed at the module level
+__all__ = ['log', 'expand_site_table', 'collapse_rows', 'exp_semi_col', 'merge_semi_cols', 'calculate_iBAQ', 'merge_semi_cols']
 
 # =============================================================================
 # Note: When using R functions provided column names might get changed

--- a/autoprot/preprocessing/transformation.py
+++ b/autoprot/preprocessing/transformation.py
@@ -124,7 +124,11 @@ def log(
 
     df = df.copy()
     # values to keep for log transformation
-    keep = df[cols] > 0
+    try:
+        keep = df[cols] > 0
+    except TypeError:
+        raise TypeError(f"[log] Could not mask negative an NaN values in columns {', '.join(cols)}."
+                        f" Please check if they are all numerical.")
 
     # Apply log transformation to all columns at once
     log_values = np.log(df[cols].where(keep)) / np.log(base)

--- a/autoprot/r_helper.py
+++ b/autoprot/r_helper.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 from subprocess import run, STDOUT, Popen, PIPE
+
 import pandas as pd
 
 # this is a pointer to the module object instance itself.
@@ -100,13 +101,21 @@ def check_r_install():
     base_path = str(os.path.join(os.path.dirname(os.path.realpath(__file__))))
 
     if not os.path.isfile(os.path.join(base_path, "autoprot.conf")):
-        with open(os.path.join(base_path, "autoprot.conf"), "w") as wf:
-            wf.write(
-                f"R = PATH_TO_RSCRIPT\nRFUNCTIONS = {os.path.join(base_path, 'RFunctions.R')}"
+        # check if you have write permissions
+        if not os.access(os.path.join(base_path, "autoprot.conf")):
+            raise OSError(
+                f"Could not create autoprot.conf file at {os.path.join(base_path, 'autoprot.conf')}. "
+                f"Please create a file with the following content and place at this dir:"
+                f" \n R = PATH_TO_RSCRIPT\nRFUNCTIONS = {os.path.join(base_path, 'RFunctions.R')}"
             )
-        raise OSError(
-            "No R installation configured. Generated autoprot.conf. Please edit and try again."
-        )
+        else:
+            with open(os.path.join(base_path, "autoprot.conf"), "w") as wf:
+                wf.write(
+                    f"R = PATH_TO_RSCRIPT\nRFUNCTIONS = {os.path.join(base_path, 'RFunctions.R')}"
+                )
+            raise OSError(
+                "No R installation configured. Generated autoprot.conf. Please edit and try again."
+            )
     else:
         with open(os.path.join(base_path, "autoprot.conf"), "r") as rf:
             for line in rf:

--- a/autoprot/visualization/__init__.py
+++ b/autoprot/visualization/__init__.py
@@ -1,3 +1,10 @@
 from .annotation import *
 from .qc import *
 from .basic import *
+
+# Optional: define what's exported when someone does `from visualization import *`
+__all__ = [
+    'annotation',
+    'qc',
+    'basic',
+]

--- a/autoprot/visualization/__init__.py
+++ b/autoprot/visualization/__init__.py
@@ -1,10 +1,10 @@
 from .annotation import *
-from .qc import *
 from .basic import *
+from .qc import *
 
 # Optional: define what's exported when someone does `from visualization import *`
 __all__ = [
-    'annotation',
-    'qc',
-    'basic',
+    "annotation",
+    "qc",
+    "basic",
 ]

--- a/autoprot/visualization/annotation.py
+++ b/autoprot/visualization/annotation.py
@@ -22,10 +22,10 @@ from plotly.subplots import make_subplots
 import logomaker
 import matplotlib.patches as patches
 
-from ..dependencies.plotlylogo.PlotlyLogo import logo as plogo
+from autoprot.dependencies.plotlylogo.PlotlyLogo import logo as plogo
 
 # SEQUENCE LOGO
-
+__all__ = ['sequence_logo', 'isequence_logo', 'vis_psites', 'ivis_psites', 'ptm_lolli_plot', 'ptm_mirror_lolli_plot', 'i_lolli_plot', 'i_mirror_lolli_plot']
 
 def _find_sequence_motif(row: pd.Series, sequence_motif: str, rename_to_st=False):
     """

--- a/autoprot/visualization/annotation.py
+++ b/autoprot/visualization/annotation.py
@@ -9,23 +9,32 @@ Autoprot Annotation Functions.
 
 from typing import Union
 
-import pandas as pd
-import numpy as np
-import seaborn as sns
+import logomaker
+import matplotlib.patches as patches
 import matplotlib.pylab as plt
-import plotly.graph_objects as go
+import numpy as np
+import pandas as pd
 import plotly.express as px
+import plotly.graph_objects as go
+import seaborn as sns
 from pandas import DataFrame
 from plotly.graph_objs import Figure
 from plotly.subplots import make_subplots
 
-import logomaker
-import matplotlib.patches as patches
-
 from autoprot.dependencies.plotlylogo.PlotlyLogo import logo as plogo
 
 # SEQUENCE LOGO
-__all__ = ['sequence_logo', 'isequence_logo', 'vis_psites', 'ivis_psites', 'ptm_lolli_plot', 'ptm_mirror_lolli_plot', 'i_lolli_plot', 'i_mirror_lolli_plot']
+__all__ = [
+    "sequence_logo",
+    "isequence_logo",
+    "vis_psites",
+    "ivis_psites",
+    "ptm_lolli_plot",
+    "ptm_mirror_lolli_plot",
+    "i_lolli_plot",
+    "i_mirror_lolli_plot",
+]
+
 
 def _find_sequence_motif(row: pd.Series, sequence_motif: str, rename_to_st=False):
     """

--- a/autoprot/visualization/basic.py
+++ b/autoprot/visualization/basic.py
@@ -50,6 +50,7 @@ def correlogram(
     ret_fig: bool = False,
     correlation_colorrange: tuple[float, float] = (0.8, 1),
     figsize: Union[bool, tuple] = None,
+    to_count: str = 'proteins'
 ):
     # noinspection PyUnresolvedReferences
     """Plot a pair plot of the dataframe intensity columns in order to assess the reproducibility.
@@ -97,6 +98,8 @@ def correlogram(
         Sets the colormap range for the upper-right correlation tiles. Default is (0.8, 1)
     figsize : tuple, optional
         The figure size in x and y direction.
+    to_count: str
+        Label for the number of elements counted (depends on the input file)
 
     Raises
     ------
@@ -251,11 +254,6 @@ def correlogram(
         _ = kwargs  # kwargs required to catch seaborn calling kwargs color and label
         r, d = calculate_correlation(x, y)
         ax = plt.gca()
-
-        if file == "Phospho (STY)":
-            to_count = "peptides"
-        else:
-            to_count = "proteins"
 
         ax.annotate(f"{len(d)} {to_count}", xy=(0.1, 0.9), xycoords=ax.transAxes)
         ax.annotate(

--- a/autoprot/visualization/basic.py
+++ b/autoprot/visualization/basic.py
@@ -29,11 +29,32 @@ from scipy import stats
 from scipy.linalg import LinAlgError
 from scipy.stats import zscore, gaussian_kde
 
-from .. import common as com
-from ..dependencies.venn import venn
+from autoprot import common as com
+from autoprot.dependencies.venn import venn
 
 # ignore FutureWarnings from upsetplot
 warnings.filterwarnings("ignore", module="upsetplot", category=FutureWarning)
+
+__all__ = [
+    "correlogram",
+    "corr_map",
+    "prob_plot",
+    "boxplot",
+    "intensity_rank",
+    "venn_diagram",
+    "volcano",
+    "ivolcano",
+    "ratio_plot",
+    "iratio_plot",
+    "ratio_vs_intens",
+    "log_int_plot",
+    "ilog_int_plot",
+    "ma_plot",
+    "ima_plot",
+    "mean_sd_plot",
+    "plot_traces",
+    "pval_hist",
+]
 
 
 def correlogram(
@@ -50,7 +71,7 @@ def correlogram(
     ret_fig: bool = False,
     correlation_colorrange: tuple[float, float] = (0.8, 1),
     figsize: Union[bool, tuple] = None,
-    to_count: str = 'proteins'
+    to_count: str = "proteins",
 ):
     # noinspection PyUnresolvedReferences
     """Plot a pair plot of the dataframe intensity columns in order to assess the reproducibility.

--- a/autoprot/visualization/qc.py
+++ b/autoprot/visualization/qc.py
@@ -14,6 +14,15 @@ import matplotlib.ticker as ticker
 import plotly.express as px
 from typing import Literal, Union
 
+__all__ = [
+    "sty_count_plot",
+    "isty_count_plot",
+    "charge_plot",
+    "icharge_plot",
+    "count_mod_aa",
+    "icount_mod_aa",
+]
+
 
 def _bar_plot_style(df, ax):
     """

--- a/autoprot/visualization/qc.py
+++ b/autoprot/visualization/qc.py
@@ -7,12 +7,13 @@ Autoprot Quality Control Plotting Functions.
 @documentation: Julian
 """
 
-import pandas as pd
-import seaborn as sns
+from typing import Literal, Union
+
 import matplotlib.pylab as plt
 import matplotlib.ticker as ticker
+import pandas as pd
 import plotly.express as px
-from typing import Literal, Union
+import seaborn as sns
 
 __all__ = [
     "sty_count_plot",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "seaborn>=0.13.2",
     "statsmodels>=0.13.2",
     "UpSetPlot>=0.8.0",
-    "pandera>=0.1"
+    "pandera>=0.1",
 ]
 
 [project.optional-dependencies]
@@ -40,6 +40,7 @@ docs = [
     "numpydoc>=1.7.0",
     "pydata-sphinx-theme>=0.15.2",
     "myst-parser>=3.0.1"
+    "black>=26.3.1",
 ]
 
 testing = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autoprot"
-version = "0.3.0"
+version = "0.3.1"
 description = "Automated Proteomics Analysis"
 authors = [
     { name = "Julian Bender", email = "julian.bender@uni-wuerzburg.de" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "scipy>=1.7.3",
     "seaborn>=0.13.2",
     "statsmodels>=0.13.2",
-    "UpSetPlot>=0.8.0"
+    "UpSetPlot>=0.8.0",
+    "pandera>=0.1"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ docs = [
     "Sphinx>=7.3.7",
     "numpydoc>=1.7.0",
     "pydata-sphinx-theme>=0.15.2",
-    "myst-parser>=3.0.1"
+    "myst-parser>=3.0.1",
     "black>=26.3.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ testing = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["autoprot"]
+include = ["autoprot", "autoprot.preprocessing", "autoprot.analysis", "autoprot.visualization",
+    "autoprot.dependencies", "autoprot.dependencies.plotlylogo", "autoprot.dependencies.venn"]
 
 [tool.pixi.workspace]
 channels = ["conda-forge", "bioconda"]


### PR DESCRIPTION
These commits change the (previously slightly random) manner modules were imported in autoprot. The files now enable consistent calling of functions and the adapted pyproject.toml allows installing via pip.